### PR TITLE
Using http as the protocol when the host name is set to localhost

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,7 +51,7 @@ async function loadResource() {
 
   const config: AppConfig = {
     ndexUrl,
-    ndexHttps: `https://${ndexUrl}`,
+    ndexHttps: (ndexUrl === 'localhost')? `http://${ndexUrl}`: `https://${ndexUrl}`,
     googleClientId,
     viewerThreshold: viewerTh,
     maxNumObjects,


### PR DESCRIPTION
This is for our internal development, when I try to point NNV to my local instance of ndex rest server.