### PR TITLE
Fixed UD-2498

### DIFF
--- a/src/components/NetworkPanel/index.tsx
+++ b/src/components/NetworkPanel/index.tsx
@@ -533,7 +533,14 @@ const NetworkPanel = ({
   }
 
   const getSubRenderer = () => {
-    // Case 1:
+    // Check the error code 500:
+    if (searchResult.error && typeof searchResult.error === 'object' && 'message' in searchResult.error) {
+      if (searchResult.error.message === '500') {
+        const message = 'Oops! We\'re having trouble connecting to the server.'
+        return <Loading message={message} showLoading={false} />
+      }
+    }
+
     if (!searchResult.isLoading && subCx === undefined && showSearchResult) {
       const message = 'No search result yet.'
       return <Loading message={message} showLoading={false} />

--- a/src/components/NetworkPanel/index.tsx
+++ b/src/components/NetworkPanel/index.tsx
@@ -536,7 +536,7 @@ const NetworkPanel = ({
     // Check the error code 500:
     if (searchResult.error && typeof searchResult.error === 'object' && 'message' in searchResult.error) {
       if (searchResult.error.message === '500') {
-        const message = 'Oops! We\'re having trouble connecting to the server.'
+        const message = 'The service is temporarily unavailable. Please contact us for assistance.'
         return <Loading message={message} showLoading={false} />
       }
     }

--- a/src/components/NetworkPanel/index.tsx
+++ b/src/components/NetworkPanel/index.tsx
@@ -536,7 +536,7 @@ const NetworkPanel = ({
     // Check the error code 500:
     if (searchResult.error && typeof searchResult.error === 'object' && 'message' in searchResult.error) {
       if (searchResult.error.message === '500') {
-        const message = 'The service is temporarily unavailable. Please contact us for assistance.'
+        const message = 'The service is temporarily unavailable. Please try again later.'
         return <Loading message={message} showLoading={false} />
       }
     }


### PR DESCRIPTION
**Solution**: Check whether `searchResult.error` exists and its `errorcode` is 500. If both conditions are met, then the message would be displayed on the screen.

**To be discussed**: the error message 
For now I just set the error message as 'Oops! We're having trouble connecting to the server.'

<img width="1470" alt="image" src="https://github.com/idekerlab/network-viewer/assets/39005000/8ba6ff1e-8079-41f1-b3e8-ef8d688e00fe">
