### PR TITLE
Solved Bug UD-2477

### DIFF
--- a/src/components/FooterPanel/DeleteButton.tsx
+++ b/src/components/FooterPanel/DeleteButton.tsx
@@ -52,13 +52,15 @@ const DeleteButton: VFC = (): ReactElement => {
   }
 
   let message = 'Delete function is only available to signed-in users'
-
   let disabled = true
-  if (readOnly) {
-    message = 'This network is read-only'
-  } else if (hasPermission && login) {
-    message = 'Delete this network'
-    disabled = false
+
+  if (hasPermission && login) {
+    if(readOnly){
+      message = 'This network is read-only'
+    }else{
+      message = 'Delete this network'
+      disabled = false
+    }
   } else if (!hasPermission && login) {
     message = "You don't have permission to delete this network"
   }

--- a/src/components/FooterPanel/DeleteButton.tsx
+++ b/src/components/FooterPanel/DeleteButton.tsx
@@ -71,7 +71,7 @@ const DeleteButton: VFC = (): ReactElement => {
     <Tooltip title={message} arrow placement={'top-start'}>
       <div>
         <IconButton color="inherit" disabled={disabled} onClick={_handleClick}>
-          {readOnly ? <LockIcon /> : <DeleteIcon />}
+          <DeleteIcon/>
         </IconButton>
         <DeleteDialog open={open} setOpen={setOpen} />
       </div>


### PR DESCRIPTION
Called the `useNetworkSummary` hook in Delete component to determine whether the network is **read-only** or not. If yes, the button would be disabled and it shows the **LockIcon**.
<img width="1512" alt="image" src="https://github.com/idekerlab/network-viewer/assets/39005000/8dd7d072-d48f-47fc-96d3-4d518f3ff25f">

Ref: [Jira Ticket](https://ndexbio.atlassian.net/browse/UD-2477)