### PR TITLE
Solved Bug UD-2485

### DIFF
--- a/src/hooks/useCyjs.ts
+++ b/src/hooks/useCyjs.ts
@@ -1,6 +1,8 @@
 import { cx2cyjs } from '../utils/cx2cyjs'
 import { useState } from 'react'
 import NDExError from '../utils/error/NDExError'
+// Minimum Length of CX: 'numberVerification' and 'status' are the two essential entries in cx.
+const CX_MIN_LEN = 2 
 
 export default function useCyjs(uuid: string, cx: object[]) {
   const [cyjs, setCyjs] = useState(null)
@@ -11,7 +13,7 @@ export default function useCyjs(uuid: string, cx: object[]) {
     return {}
   }
 
-  if (id === null && cx.length >= 6) {
+  if (id === null && cx.length >= CX_MIN_LEN) {
     setUuid(uuid)
 
     try {


### PR DESCRIPTION
**Original Ticket**: [Jira Ticket UD-2485](https://ndexbio.atlassian.net/browse/UD-2485)

### Identification of the Issue:
The root cause of the bug can be traced to the following` if `condition: `if (id === null && cx.length >= 6)`. This condition is currently preventing certain cx files from being converted to `cyjs` format. As shown in the cx file example below, which contains only **4** entries, the preset minimum length requirement for cx files is overly restrictive, potentially excluding valid networks from being correctly renderred.

### Proposed Resolution:
Following a discussion with @jingjingbic, it is proposed to change the minimum length requirement for a cx file to **2,** which means that `'numberVerification'` and `'status'` are the only 2 essential entries in a cx file. 

#### CX File:

```
[
{"numberVerification":[{"longNumber":281474976710655}]},
{"metaData":[{"name":"nodes","elementCount":1,"idCounter":1,"version":"1.0","consistencyGroup":1}]},
{"nodes":[{"@id":0,"n":"node1","r":"node1"}]},
{"status":[{"error":"","success":true}]}
]
```