### PR TITLE
Solved Bug UD-2776

### DIFF
--- a/src/components/FooterPanel/SaveQueryButton.tsx
+++ b/src/components/FooterPanel/SaveQueryButton.tsx
@@ -58,6 +58,7 @@ const SaveQueryButton = () => {
           onSuccess={onSuccess}
           onFailure={onFailure}
           subCx={subCx}
+          showLoginTip = {!isLogin}
         />
         <Snackbar
           anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}

--- a/src/components/SaveToNdexButton/SaveToNdexButton.tsx
+++ b/src/components/SaveToNdexButton/SaveToNdexButton.tsx
@@ -31,6 +31,9 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSizeLarge: '26px',
     },
     toolTipSpan: {},
+    disabledButtonWrapper: {
+      display: 'inline-flex', 
+    },
   }),
 )
 
@@ -39,6 +42,7 @@ type SaveToNdexButtonProps = {
   subCx?: any[]
   onSuccess?: (data: any) => void
   onFailure?: (err: any) => void
+  showLoginTip?: boolean
 }
 
 export const SaveToNdexButton = ({
@@ -46,6 +50,7 @@ export const SaveToNdexButton = ({
   onSuccess,
   onFailure,
   subCx,
+  showLoginTip = false
 }: SaveToNdexButtonProps): JSX.Element => {
   const classes = useStyles()
 
@@ -77,16 +82,21 @@ export const SaveToNdexButton = ({
       }
     }
   }
+  const tooltipTitle = (showLoginTip)
+    ? 'You must be logged in to save'
+    : 'Save to NDEx';
 
   return (
-    <Tooltip disableFocusListener title={'Save to NDEx'}>
-      <IconButton
-        className={classes.button}
-        onClick={onClick}
-        disabled={disabled}
-      >
-        <SaveIcon />
-      </IconButton>
+    <Tooltip disableFocusListener title={tooltipTitle}>
+      <span className={classes.disabledButtonWrapper}> 
+        <IconButton
+          className={classes.button}
+          onClick={onClick}
+          disabled={disabled}
+        >
+          <SaveIcon />
+        </IconButton>
+      </span>
     </Tooltip>
   )
 }

--- a/src/components/SaveToNdexButton/SaveToNdexButton.tsx
+++ b/src/components/SaveToNdexButton/SaveToNdexButton.tsx
@@ -83,8 +83,8 @@ export const SaveToNdexButton = ({
     }
   }
   const tooltipTitle = (showLoginTip)
-    ? 'You must be logged in to save'
-    : 'Save to NDEx';
+    ? 'Save query result function is only available to signed-in users'
+    : 'Save query result to NDEx';
 
   return (
     <Tooltip disableFocusListener title={tooltipTitle}>


### PR DESCRIPTION
Ref: [Jira Ticket](https://ndexbio.atlassian.net/browse/UD-2776)
Added such a logic: if the **search results** is shown and the user is **NOT logged in**, then newly added property `showLoginTip` of the component `SaveToNdexButton`  would be True, and show the **ToolTip** '_You must be logged in to save_' instead of the default one: '_Save to NDEx_'.