### PR TITLE
Solved Bug of wrongly showing "Dummy Node" for edges without names

### DIFF
--- a/src/components/Popup/index.tsx
+++ b/src/components/Popup/index.tsx
@@ -190,6 +190,9 @@ const Popup: FC<PopupProps> = ({ cx, subHeight }: PopupProps) => {
   if (target) {
     nonEmptyMap.set(EdgeAttributes.TARGET, target)
   }
+  if (interaction) {
+    nonEmptyMap.set(EdgeAttributes.INTERACTION, interaction)
+  }
 
   //Calculate position based on pointer position in window
   const x = lastSelected.coordinates.x

--- a/src/components/Popup/index.tsx
+++ b/src/components/Popup/index.tsx
@@ -99,8 +99,10 @@ const Popup: FC<PopupProps> = ({ cx, subHeight }: PopupProps) => {
   }
 
   const id = selectionState.lastSelected.id
+  const isNode = selectionState.lastSelected.isNode
+
   let attrMap = null
-  if (selectionState.lastSelected.isNode) {
+  if (isNode) {
     attrMap = attr.nodeAttr[id]
   } else {
     attrMap = attr.edgeAttr[id]
@@ -113,7 +115,7 @@ const Popup: FC<PopupProps> = ({ cx, subHeight }: PopupProps) => {
   const include = []
 
   for (let item of attrMap) {
-    if (!selectionState.lastSelected.isNode) {
+    if (!isNode) {
       if (
         [
           EdgeAttributes.SOURCE,
@@ -235,7 +237,7 @@ const Popup: FC<PopupProps> = ({ cx, subHeight }: PopupProps) => {
 
   return (
     <div className={classes.root} style={style}>
-      <PropertyPanel attrMap={nonEmptyMap} onClose={onClose} />
+      <PropertyPanel attrMap={nonEmptyMap} onClose={onClose} isNode={isNode} />
     </div>
   )
 }

--- a/src/components/PropertyPanel/index.tsx
+++ b/src/components/PropertyPanel/index.tsx
@@ -37,49 +37,29 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 )
 
-const PropertyPanel = ({ attrMap, onClose }) => {
+const PropertyPanel = ({ attrMap, onClose, isNode }) => {
   const classes = useStyles()
 
   const handleClose = () => {
     onClose()
   }
-  if (attrMap.size > 0 && attrMap.get('name')){
-    return (
-      <div className={classes.root}>
-        <div className={classes.title}>
-          <Typography className={classes.name} variant="body1">
-            {attrMap.get('name')}
-          </Typography>
-          <IconButton onClick={handleClose}>
-            <CloseIcon />
-          </IconButton>
-        </div>
-        <div className={classes.propList}>
-          <div>
-            <PropList attrMap={attrMap} />
-          </div>
+  return (
+    <div className={classes.root}>
+      <div className={classes.title}>
+        <Typography className={classes.name} variant="body1">
+          {attrMap.get('name') ?? ''}
+        </Typography>
+        <IconButton onClick={handleClose}>
+          <CloseIcon />
+        </IconButton>
+      </div>
+      <div className={classes.propList}>
+        <div>
+          <PropList attrMap={attrMap} />
         </div>
       </div>
-    )    
-  }else{
-    console.log(attrMap)
-    return (
-      <div className={classes.root}>
-        <div className={classes.title}>
-          <Typography className={classes.name} variant="body1">
-            Dummy Node
-          </Typography>
-          <IconButton onClick={handleClose}>
-            <CloseIcon />
-          </IconButton>
-        </div>
-        <div className={classes.propList}>
-          No attributes are defined for this node.
-        </div>
-      </div>
-    )
-  }
-
+    </div>
+  )
 }
 
 export default PropertyPanel


### PR DESCRIPTION
Jira: [UD-2893](https://ndexbio.atlassian.net/browse/UD-2893)
- If the edge name is empty, then leave the title of panel empty
- Add the information of "Interaction" in the edge property panel
<img width="903" alt="image" src="https://github.com/user-attachments/assets/c62b6929-fe97-4334-9e1a-d141ad0e94c6">


[UD-2893]: https://ndexbio.atlassian.net/browse/UD-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ