### PR TITLE
Table cell render bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,6 @@ const App = ({ config, keycloak, credential }) => {
   )
 
   const [isReady, setIsReady] = useState<boolean>(false)
-  const [showLogin, setShowLogin] = useState<boolean>(false)
 
   // TODO: use reducer?
   const defState: AppState = {
@@ -90,9 +89,6 @@ const App = ({ config, keycloak, credential }) => {
     keycloak,
     isReady,
     setIsReady,
-
-    showLogin,
-    setShowLogin,
   }
 
   const routes = [

--- a/src/components/DataPanel/EntryTable/VirtualizedTable2.tsx
+++ b/src/components/DataPanel/EntryTable/VirtualizedTable2.tsx
@@ -335,6 +335,9 @@ const VirtualizedTable2: FC<{
 
   // Render a cell in the column header.
   const _renderLeftHeaderCell = ({ columnIndex, key, style }) => {
+    if (headerGroups.length === 0) {
+      return
+    }
     const headerGroup = headerGroups[0]
     const column = headerGroup.headers[columnIndex]
 
@@ -469,7 +472,6 @@ const VirtualizedTable2: FC<{
         return <p className={classes.cellOverflow}>[{value.slice(0, 2)} ...]</p>
       } else {
         return <p className={classes.cellOverflow}>[{value} ...]</p>
-
       }
     }
   }

--- a/src/components/FooterPanel/SaveNetworkCXButton.tsx
+++ b/src/components/FooterPanel/SaveNetworkCXButton.tsx
@@ -8,7 +8,6 @@ import Tooltip from '@material-ui/core/Tooltip'
 import DownloadIcon from '@material-ui/icons/CloudDownload'
 
 import { appendWindowProtocol } from '../../utils/locationUtil'
-import { AuthType } from '../../model/AuthType'
 
 const SaveNetworkCXButton = () => {
   const { uuid } = useParams()

--- a/src/components/MainSplitPane/InitializationPanel.tsx
+++ b/src/components/MainSplitPane/InitializationPanel.tsx
@@ -1,9 +1,9 @@
 import React, { useState, FC, useEffect, useContext } from 'react'
-import { useParams } from 'react-router-dom'
 import MessageDialog from './MessageDialog'
 import { createStyles, Theme, makeStyles } from '@material-ui/core/styles'
 import { Typography } from '@material-ui/core'
 import CircularProgress from '@material-ui/core/CircularProgress'
+import NdexCredential from '../../model/NdexCredential'
 
 // import WarningIcon from '@material-ui/icons/WarningOutlined'
 // import LockIcon from '@material-ui/icons/LockOutlined'
@@ -95,7 +95,8 @@ const InitPanel: FC<InitPanelProps> = ({
   setNoView,
 }) => {
   const classes = useStyles()
-  const { config, uiState, setShowLogin } = useContext(AppContext)
+  const { config, uiState, keycloak, setNdexCredential } =
+    useContext(AppContext)
 
   const [open, setOpen] = useState(false)
 
@@ -147,7 +148,23 @@ const InitPanel: FC<InitPanelProps> = ({
   }
 
   const _handleLoginOpen = () => {
-    setShowLogin(true)
+    keycloak.login().then(() => {
+      if (keycloak.authenticated) {
+        setNdexCredential({
+          authenticated: true,
+          userName: keycloak.tokenParsed.preferred_username,
+          accesskey: keycloak.token,
+          fullName: keycloak.tokenParsed.name,
+        } as NdexCredential)
+        console.log('Login successfully')
+      } else {
+        // Failed
+        setNdexCredential({
+          authenticated: false,
+        } as NdexCredential)
+        console.log('Not authenticated')
+      }
+    })
   }
 
   if (error) {

--- a/src/components/NdexLogin/NdexSignInButton/NdexSignInButton.tsx
+++ b/src/components/NdexLogin/NdexSignInButton/NdexSignInButton.tsx
@@ -6,6 +6,8 @@ import { useStyles } from './buttonStyle'
 import AppContext from '../../../context/AppState'
 import { NdexUserInfoPopover } from '../NdexUserInfoPopover'
 import NdexCredential from '../../../model/NdexCredential'
+import { Visibility } from '../../../model/Visibility'
+import { getCurrentServer } from '../../../utils/locationUtil'
 
 /**
  * Simplified version of NDEx login button
@@ -44,7 +46,15 @@ export const NdexSignInButton = () => {
     setNdexCredential({
       authenticated: false,
     })
-    keycloak.logout()
+    const { visibility } = summary
+
+    if (visibility === Visibility.PUBLIC) {
+      keycloak.logout()
+    } else {
+      // if it is private network, then redirect to NDEx
+      const baseUrl: string = getCurrentServer()
+      keycloak.logout({ redirectUri: baseUrl })
+    }
   }
 
   const getTitle = (): string => {

--- a/src/components/NdexLogin/NdexSignInButton/NdexSignInButton.tsx
+++ b/src/components/NdexLogin/NdexSignInButton/NdexSignInButton.tsx
@@ -19,15 +19,8 @@ export const NdexSignInButton = () => {
   const [disabled, setDisabled] = useState<boolean>(true)
 
   // New Keycloak client
-  const {
-    config,
-    keycloak,
-    ndexCredential,
-    setNdexCredential,
-    showLogin,
-    setShowLogin,
-    summary,
-  } = useContext(AppContext)
+  const { config, keycloak, ndexCredential, setNdexCredential, summary } =
+    useContext(AppContext)
 
   useEffect(() => {
     if (ndexCredential === undefined || keycloak === undefined) {
@@ -46,23 +39,6 @@ export const NdexSignInButton = () => {
     setAnchorEl(null)
   }
 
-  const [errorMessage, setErrorMessage] = useState<string>('')
-
-  const onLoginSuccess = (event): void => {
-    console.log('Login success', event)
-  }
-
-  const postLogout = (): void => {
-    console.log('Post logout cleanup')
-    const { visibility } = summary
-
-    setShowLogin(false)
-    if (visibility === 'PRIVATE') {
-      setTimeout(() => {
-        window.location.reload()
-      }, 500)
-    }
-  }
   const onLogout = (): void => {
     // Clear credential from global state
     setNdexCredential({
@@ -70,13 +46,6 @@ export const NdexSignInButton = () => {
     })
     keycloak.logout()
   }
-
-  const handleError = (error) => {
-    console.log('Error:', error)
-    setErrorMessage(error)
-  }
-
-  const onError = (error: any) => {}
 
   const getTitle = (): string => {
     return ndexCredential.authenticated

--- a/src/components/OpenInCytoscapeButton/OpenInCytoscapeButton.tsx
+++ b/src/components/OpenInCytoscapeButton/OpenInCytoscapeButton.tsx
@@ -8,7 +8,6 @@ import Tooltip from '@material-ui/core/Tooltip'
 import { CyNDEx } from '@js4cytoscape/ndex-client'
 import LargeNetworkDialog from './LargeNetworkDialog'
 import AppContext from '../../context/AppState'
-import { AuthType } from '../../model/AuthType'
 import { useCyNdexValue } from './CyNdexContext'
 
 const styles = () => ({

--- a/src/model/AppState.ts
+++ b/src/model/AppState.ts
@@ -35,9 +35,6 @@ type AppState = {
   ndexCredential: NdexCredential
   setNdexCredential: (credential: NdexCredential) => void
 
-  showLogin: boolean
-  setShowLogin: (showDialog: boolean) => void
-
   isReady: boolean
   setIsReady: (isReady: boolean) => void
 }

--- a/src/model/Visibility.ts
+++ b/src/model/Visibility.ts
@@ -1,0 +1,7 @@
+export const Visibility = {
+    PUBLIC: 'PUBLIC',
+    PRIVATE: 'PRIVATE',
+  } as const
+  
+  export type Visibility = (typeof Visibility)[keyof typeof Visibility]
+  

--- a/src/utils/error/errorHandler.ts
+++ b/src/utils/error/errorHandler.ts
@@ -11,7 +11,7 @@ MESSAGE_MAP.set(ResponseCode.BadRequest, [
 ])
 MESSAGE_MAP.set(ResponseCode.Unauthorized, [
   "You don't have permission to access this data",
-  'Please sing in to your account and check the permission of this entry',
+  'Please sign in to your account and check the permission of this entry',
 ])
 MESSAGE_MAP.set(ResponseCode.InternalServerError, [
   'Unknown server-side error.',


### PR DESCRIPTION
This [Ticket](https://ndexbio.atlassian.net/browse/UD-2964) is a bug occurs when the network is large and does not have  a layout:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/053f23c5-be74-41a5-9ad2-21d86258fa5b">

#### 1. OK -> Apply random layout -> Sometimes the network view is blank
#### 2. Cancel -> No network view -> Table cells do not render correctly.

#### 1. The network view becomes blank
This bug happens **randomly** and is related to the package [`deck.gl`](https://deck.gl/docs). Since the layout is randomized and the network size is large, some pixel project matrix becomes non-invertible during rendering. As a result, the network view fails to render and appears blank.

<img width="940" alt="image" src="https://github.com/user-attachments/assets/79416d35-b3de-46d9-9aec-e08f77dbe51a">

In summary, when no pixel project matrices are non-invertible during calculations in the `deck.gl`, the network view can be rendered correctly, otherwise, it would become blank. I also tried to upgrade the package version from `8.x` to `9.0` but the bug still occurs from time to time.

|Matrix is NOT invertible |Matrix is invertible|
|-----|-----|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/037c0e4e-c116-41af-9bf1-05b4613b8aa4">|<img width="400" alt="image" src="https://github.com/user-attachments/assets/ff73feb9-11a8-4131-ba5d-a2ac39b50610">|


#### 2. Cell Not Rendered Correctly
This issue can be resolved by checking for empty data before rendering(See `src/components/DataPanel/EntryTable/VirtualizedTable2.tsx`). Once addressed, selecting the "Cancel" option will bring users to the following screen:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/49faca98-e164-42ae-a7cf-5844f439915b">
